### PR TITLE
Make All Fortnite Endpoints Dynamic

### DIFF
--- a/pages/api/fortnite/fortnite/api/calendar/v1/timeline.js
+++ b/pages/api/fortnite/fortnite/api/calendar/v1/timeline.js
@@ -1,7 +1,8 @@
 // TODO change the season dynamically once we support more seasons
-const timelineResponse = require('./timelines/s6.json');
+let timelineResponse = require('./timelines/s6.json');
 
 export default function timeline(req, res) {
     // TODO change "currentTime" to current server time instead of hardcoded value
+    timelineResponse.currentTime = new Date().toISOString();
     res.json(timelineResponse);
 }

--- a/pages/api/fortnite/fortnite/api/calendar/v1/timelines/s6.json
+++ b/pages/api/fortnite/fortnite/api/calendar/v1/timelines/s6.json
@@ -96,5 +96,5 @@
     },
     "eventsTimeOffsetHrs":0,
     "cacheIntervalMins":10,
-    "currentTime":"2021-01-03T16:22:20.000Z"
+    "currentTime":""
  }


### PR DESCRIPTION
The only endpoint that was not dynamic was the timeline endpoint. The timeline endpoint's `currentTime` field was hardcoded to an older date. This has been change to point to the current time.

resolves #9